### PR TITLE
Updated PHPDocs and case-insensitive problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ vendor
 # Test
 coverage
 
+# JetBrains PhpStorm generated folder
+.idea

--- a/src/Content/CFileContent.php
+++ b/src/Content/CFileContent.php
@@ -24,7 +24,7 @@ class CFileContent
      *
      * @return string as content of the file
      *
-     * @throws Exception when file does not exist
+     * @throws \Exception when file does not exist
      */
     public function get($file)
     {
@@ -38,13 +38,13 @@ class CFileContent
     }
 
 
-
     /**
      * Set base path where  to find content.
      *
      * @param string $path where content reside
-     *
+     * 
      * @return $this
+     * @throws \Exception
      */
     public function setBasePath($path)
     {

--- a/src/DI/CDI.php
+++ b/src/DI/CDI.php
@@ -33,7 +33,7 @@ class CDI implements IDI
     /**
      * Return an arry with all loaded services names.
      *
-     * @return void
+     * @return array
      */
     public function getServices()
     {
@@ -45,7 +45,7 @@ class CDI implements IDI
     /**
      * Return an array with all loaded services that are controllers.
      *
-     * @return void
+     * @return array
      */
     public function getControllers()
     {
@@ -62,7 +62,7 @@ class CDI implements IDI
     /**
      * Return an arry with all active services names.
      *
-     * @return void
+     * @return array
      */
     public function getActiveServices()
     {
@@ -80,7 +80,7 @@ class CDI implements IDI
      *      actually load, insantiate, the serviceobject.
      * @param boolean $singleton set if service is to act as singleton or not, default is false.
      *
-     * @return nothing.
+     * @return void
      */
     public function set($service, $loader, $singleton = false)
     {
@@ -99,7 +99,7 @@ class CDI implements IDI
      *                        instance of the service object. Its the way
      *                        to actually load, insantiate, the serviceobject.
      *
-     * @return nothing.
+     * @return void
      */
     public function setShared($service, $loader)
     {
@@ -114,7 +114,7 @@ class CDI implements IDI
      * @param string $service as a service label, naming this service.
      *
      * @return object as instance of the service object.
-     * @throws Exception when service accessed is not loaded.
+     * @throws \Exception when service accessed is not loaded.
      */
     public function get($service)
     {
@@ -147,7 +147,7 @@ class CDI implements IDI
      *
      * @param string $service name of class property not existing.
      *
-     * @return class as the service requested.
+     * @return object as the service requested.
      */
     public function __get($service)
     {
@@ -179,7 +179,7 @@ class CDI implements IDI
      * @param string $service   name of class property not existing.
      * @param array  $arguments currently NOT USED.
      *
-     * @return class as the service requested.
+     * @return object as the service requested.
      */
     public function __call($service, $arguments = [])
     {
@@ -194,7 +194,7 @@ class CDI implements IDI
      * @param string $service as a service label, naming this service.
      *
      * @return object as instance of the service object.
-     * @throws Exception when service could not be loaded.
+     * @throws \Exception when service could not be loaded.
      */
     protected function load($service)
     {

--- a/src/DI/CDIArray.php
+++ b/src/DI/CDIArray.php
@@ -30,7 +30,8 @@ class CDIArray extends CDI implements \ArrayAccess
     /**
      * Construct.
      *
-     * @param array $options to configure options.
+     * @param mixed $offset
+     * @param mixed $value
      */
     public function offsetSet($offset, $value)
     {
@@ -42,11 +43,11 @@ class CDIArray extends CDI implements \ArrayAccess
     }
 
 
-
     /**
      * Construct.
      *
-     * @param array $options to configure options.
+     * @param array $offset to configure options.
+     * @return bool
      */
     public function offsetExists($offset)
     {
@@ -58,7 +59,7 @@ class CDIArray extends CDI implements \ArrayAccess
     /**
      * Construct.
      *
-     * @param array $options to configure options.
+     * @param array $offset to configure options.
      */
     public function offsetUnset($offset)
     {
@@ -66,11 +67,11 @@ class CDIArray extends CDI implements \ArrayAccess
     }
 
 
-
     /**
      * Construct.
      *
-     * @param array $options to configure options.
+     * @param array $offset to configure options.
+     * @return mixed|null
      */
     public function offsetGet($offset)
     {

--- a/src/DI/IDI.php
+++ b/src/DI/IDI.php
@@ -14,7 +14,7 @@ interface IDI
      * @param string $service as a service label, naming this service.
      *
      * @return object as instance of the service object.
-     * @throws Exception when service accessed is not loaded.
+     * @throws \Exception when service accessed is not loaded.
      */
     public function get($service);
 }

--- a/src/DI/IInjectionAware.php
+++ b/src/DI/IInjectionAware.php
@@ -11,7 +11,7 @@ interface IInjectionAware
     /**
      * Set the service container to use
      *
-     * @param class $di a service container
+     * @param IDI $di a service container
      *
      * @return $this
      */

--- a/src/DI/TInjectable.php
+++ b/src/DI/TInjectable.php
@@ -19,7 +19,7 @@ trait TInjectable
     /**
      * Set the service container to use
      *
-     * @param class $di a service container
+     * @param object $di a service container
      *
      * @return $this
      */
@@ -29,14 +29,14 @@ trait TInjectable
     }
 
 
-
     /**
      * Magic method to get and create services.
      * When created it is also stored as a parameter of this object.
      *
      * @param string $service name of class property not existing.
-     *
-     * @return class as the service requested.
+     * 
+     * @return object as the service requested.
+     * @throws \Exception
      */
     public function __get($service)
     {
@@ -65,15 +65,15 @@ trait TInjectable
     }
 
 
-
-   /**
+    /**
      * Magic method to get and create services as a method call.
      * When created it is also stored as a parameter of this object.
      *
-     * @param string $service   name of class property not existing.
+     * @param string $service name of class property not existing.
      * @param array  $arguments Additional arguments to sen to the method (NOT IMPLEMENTED).
      *
-     * @return class as the service requested.
+     * @return object as the service requested.
+     * @throws \Exception
      */
     public function __call($service, $arguments = [])
     {

--- a/src/DI/TInjectionAware.php
+++ b/src/DI/TInjectionAware.php
@@ -17,7 +17,7 @@ trait TInjectionAware
     /**
      * Set the service container to use
      *
-     * @param class $di a service container
+     * @param object $di a service container
      *
      * @return $this
      */

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -13,7 +13,7 @@ class Exception extends \Exception
      *
      * @param string $message the Exception message to throw.
      * @param int $code the Exception code.
-     * @param Exception previous the previous exception used for the exception chaining.
+     * @param \Exception $previous the previous exception used for the exception chaining.
      */
     public function __construct($message = "", $code = 0, $previous = null)
     {

--- a/src/Exception/ForbiddenException.php
+++ b/src/Exception/ForbiddenException.php
@@ -12,7 +12,7 @@ class ForbiddenException extends \Anax\Exception
      * Construct.
      *
      * @param string $message the Exception message to throw.
-     * @param Exception previous the previous exception used for the exception chaining.
+     * @param \Exception $previous the previous exception used for the exception chaining.
      */
     public function __construct($message = "", $previous = null)
     {

--- a/src/Exception/InternalServerErrorException.php
+++ b/src/Exception/InternalServerErrorException.php
@@ -12,7 +12,7 @@ class InternalServerErrorException extends \Anax\Exception
      * Construct.
      *
      * @param string $message the Exception message to throw.
-     * @param Exception previous the previous exception used for the exception chaining.
+     * @param \Exception $previous the previous exception used for the exception chaining.
      */
     public function __construct($message = "", $previous = null)
     {

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -12,7 +12,7 @@ class NotFoundException extends \Anax\Exception
      * Construct.
      *
      * @param string $message the Exception message to throw.
-     * @param Exception previous the previous exception used for the exception chaining.
+     * @param \Exception $previous the previous exception used for the exception chaining.
      */
     public function __construct($message = "", $previous = null)
     {

--- a/src/Flash/CFlashBasic.php
+++ b/src/Flash/CFlashBasic.php
@@ -19,7 +19,7 @@ class CFlashBasic
    /**
      * Set a message.
      *
-     * @param string a message.
+     * @param string $message a message.
      *
      * @return void
      */
@@ -33,7 +33,7 @@ class CFlashBasic
    /**
      * Get the message.
      *
-     * @return void
+     * @return string
      *
      */
     public function getMessage()

--- a/src/HTMLForm/CFormExample.php
+++ b/src/HTMLForm/CFormExample.php
@@ -8,7 +8,7 @@ namespace Anax\HTMLForm;
  */
 class CFormExample extends \Mos\HTMLForm\CForm
 {
-    use \Anax\DI\TInjectionaware,
+    use \Anax\DI\TInjectionAware,
         \Anax\MVC\TRedirectHelpers;
 
 

--- a/src/HTMLForm/FormController.php
+++ b/src/HTMLForm/FormController.php
@@ -8,7 +8,7 @@ namespace Anax\HTMLForm;
  */
 class FormController
 {
-    use \Anax\DI\TInjectionaware,
+    use \Anax\DI\TInjectionAware,
         \Anax\MVC\TRedirectHelpers;
 
 

--- a/src/HTMLForm/FormSmallController.php
+++ b/src/HTMLForm/FormSmallController.php
@@ -8,7 +8,7 @@ namespace Anax\HTMLForm;
  */
 class FormSmallController
 {
-    use \Anax\DI\TInjectionaware;
+    use \Anax\DI\TInjectionAware;
 
 
 

--- a/src/Log/CLogger.php
+++ b/src/Log/CLogger.php
@@ -42,7 +42,6 @@ class CLogger
     private $context = 'development'; // production, development or debug
 
 
-
     /**
      * Init the logger depending on its context production, development or debug.
      *

--- a/src/MVC/CDispatcherBasic.php
+++ b/src/MVC/CDispatcherBasic.php
@@ -66,7 +66,7 @@ class CDispatcherBasic implements \Anax\DI\IInjectionAware
     /**
      * Check if a controller exists with this name.
      *
-     * @return void
+     * @return bool
      */
     public function isValidController()
     {
@@ -125,11 +125,11 @@ class CDispatcherBasic implements \Anax\DI\IInjectionAware
     }
 
 
-
     /**
      * Inspect if callable and throw exception if parts is not callable.
      *
-     * @return void.
+     * @return void
+     * @throws \Exception
      */
     public function isCallableOrException()
     {

--- a/src/MVC/ErrorController.php
+++ b/src/MVC/ErrorController.php
@@ -12,15 +12,15 @@ class ErrorController
     use \Anax\DI\TInjectionAware;
 
 
-
     /**
-      * Display a page for a HTTP status code.
-      *
-      * @param string code    status code to set the http header.
-      * @param string message an optional message to display together with the error code.
-      *
-      * @return void
-      */
+     * Display a page for a HTTP status code.
+     *
+     * @param string $code status code to set the http header.
+     * @param string $message an optional message to display together with the error code.
+     *
+     * @return void
+     * @throws \Anax\Exception\NotFoundException
+     */
     public function statusCodeAction($code = null, $message = null)
     {
         $codes = [

--- a/src/Response/CResponseBasic.php
+++ b/src/Response/CResponseBasic.php
@@ -49,11 +49,11 @@ class CResponseBasic
     }
 
 
-
     /**
      * Send headers.
      *
-     * @return $this
+     * @return $this|void
+     * @throws \Exception
      */
     public function sendHeaders()
     {

--- a/src/Route/CRouteBasic.php
+++ b/src/Route/CRouteBasic.php
@@ -57,7 +57,7 @@ class CRouteBasic
     /**
      * Handle the action for the route.
      *
-     * @return void
+     * @return mixed
      */
     public function handle()
     {

--- a/src/Route/CRouterBasic.php
+++ b/src/Route/CRouterBasic.php
@@ -52,7 +52,7 @@ class CRouterBasic implements \Anax\DI\IInjectionAware
      * @param string $rule   for this route
      * @param mixed  $action null, string or callable to implement a controller for the route
      *
-     * @return class as new route
+     * @return object as new route
      */
     public function add($rule, $action = null)
     {
@@ -76,7 +76,7 @@ class CRouterBasic implements \Anax\DI\IInjectionAware
      * @param string $rule   for this route
      * @param mixed  $action null, string or callable to implement a controller for the route
      *
-     * @return class as new route
+     * @return object as new route
      */
     public function addInternal($rule, $action = null)
     {
@@ -87,14 +87,13 @@ class CRouterBasic implements \Anax\DI\IInjectionAware
     }
 
 
-
     /**
      * Add an internal (not exposed to url-matching) route to the router.
      *
-     * @param string $rule   for this route
-     * @param mixed  $action null, string or callable to implement a controller for the route
+     * @param string $rule for this route
      *
-     * @return class as new route
+     * @return object as new route
+     * @throws \Anax\Exception\NotFoundException
      */
     public function handleInternal($rule)
     {
@@ -107,11 +106,12 @@ class CRouterBasic implements \Anax\DI\IInjectionAware
     }
 
 
-
     /**
      * Handle the routes and match them towards the request, dispatch them when a match is made.
      *
      * @return $this
+     * @throws \Anax\Exception\NotFoundException
+     * @throws \Exception
      */
     public function handle()
     {

--- a/src/TConfigure.php
+++ b/src/TConfigure.php
@@ -16,13 +16,13 @@ trait TConfigure
     private $config = [];  // Store all config as an array
 
 
-
     /**
      * Read configuration from file or array'.
      *
      * @param array/string $what is an array with key/value config options or a file
      *      to be included which returns such an array.
      * @return $this for chaining.
+     * @throws Exception
      */
     public function configure($what)
     {

--- a/src/Url/CUrl.php
+++ b/src/Url/CUrl.php
@@ -209,13 +209,13 @@ class CUrl
     }
 
 
-
     /**
      * Set the type of urls to be generated, URL_CLEAN, URL_APPEND.
      *
      * @param string $type what type of urls to create.
      *
      * @return $this
+     * @throws \Exception
      */
     public function setUrlType($type)
     {

--- a/src/Validate/CValidate.php
+++ b/src/Validate/CValidate.php
@@ -19,12 +19,12 @@ class CValidate
     /**
      * Check if a value matches rules or throw exception.
      *
-     * @param mixed   $value  to check
-     * @param string  $rules  to apply when checking value
+     * @param mixed   $value to check
+     * @param string  $rules to apply when checking value
      * @param boolean $throws set to true to throw exception when check fails
      *
-     * @return boolean true or false
-     * @throws Exception when check fails
+     * @return bool true or false
+     * @throws \Exception
      */
     public function check($value, $rules, $throws = false)
     {

--- a/src/View/CViewBasic.php
+++ b/src/View/CViewBasic.php
@@ -42,11 +42,11 @@ class CViewBasic implements \Anax\DI\IInjectionAware
     }
 
 
-
     /**
      * Render the view.
      *
      * @return void
+     * @throws \Exception
      */
     public function render()
     {

--- a/src/View/CViewContainerBasic.php
+++ b/src/View/CViewContainerBasic.php
@@ -110,13 +110,13 @@ class CViewContainerBasic implements \Anax\DI\IInjectionAware
     }
 
 
-
     /**
      * Set base path where  to find views.
      *
      * @param string $path where all views reside
      *
      * @return $this
+     * @throws \Exception
      */
     public function setBasePath($path)
     {


### PR DESCRIPTION
Updated PHPDocs to fix a lot of problems where for example a function returned an array but in the PHPDoc it said the function was void.

Also fixed a case-insensitive problem when loading in a trait.