### PR TITLE
Router

### DIFF
--- a/src/MVC/CDispatcherBasic.php
+++ b/src/MVC/CDispatcherBasic.php
@@ -226,4 +226,22 @@ class CDispatcherBasic implements \Anax\DI\IInjectionAware
         $this->isCallableOrException();
         return $this->dispatch();
     }
+
+
+    /**
+     * Checks if the number of parameters given are valid.
+     * Make sure you have set and validated the controller and action before executing this function.
+     *
+     * @return bool if valid.
+     */
+    public function isParamsValid()
+    {
+        $reflection = new \ReflectionMethod($this->controller, $this->action);
+
+        if (count($this->params) === $reflection->getNumberOfParameters()) {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/src/MVC/CDispatcherBasic.php
+++ b/src/MVC/CDispatcherBasic.php
@@ -237,8 +237,10 @@ class CDispatcherBasic implements \Anax\DI\IInjectionAware
     public function isParamsValid()
     {
         $reflection = new \ReflectionMethod($this->controller, $this->action);
+        $numberOfParams = count($this->params);
 
-        if (count($this->params) === $reflection->getNumberOfParameters()) {
+        if ($numberOfParams >= $reflection->getNumberOfRequiredParameters()
+            && $numberOfParams <= $reflection->getNumberOfParameters()) {
             return true;
         }
 

--- a/test/MVC/CDispatcherBasicTest.php
+++ b/test/MVC/CDispatcherBasicTest.php
@@ -44,4 +44,33 @@ class CDispatcherBasicTest extends \PHPUnit_Framework_TestCase
         $disp->setActionName('not-exists');
         $disp->dispatch();
     }
+
+
+
+    /**
+     * Test
+     *
+     * @return void
+     */
+    public function testDispatchParamsValidator()
+    {
+        $di = new \Anax\DI\CDI();
+        $di->set("ErrorController", function () {
+            return new \Anax\MVC\ErrorController();
+        });
+        $disp = new \Anax\MVC\CDispatcherBasic();
+        $disp->setDI($di);
+
+        $disp->setControllerName("Error");
+        $disp->setActionName("statusCode");
+
+        $disp->setParams(["this", "is", "not", "valid"]);
+        $this->assertFalse($disp->isParamsValid());
+
+        $disp->setParams(["very", "valid"]);
+        $this->assertTrue($disp->isParamsValid());
+
+        $disp->setParams();
+        $this->assertTrue($disp->isParamsValid());
+    }
 }


### PR DESCRIPTION
## Major: CRouterBasic Updated

A problem with the router was that you could not use the default controller (`IndexController`).
For example if you wanted a main controller defining the simple routes like this:

``` php
class IndexController {
    // Will work for localhost
    public function indexAction() {...}

    /* Will not work for localhost/about.
     * Router will instead look for a 'about' controller with an index action.
     */
    public function aboutAction() {...}
}
```
## Where is the problem?

The problem is that if you look here at your current code:

``` php
// CRouterBasic : line 132
// If the first part of the url is only for defining the controllers name.
$dispatcher->setControllerName(isset($parts[0]) ? $parts[0] : 'index');
```

Another problem was that if you use index action with parameters, it will not work for the first parameter.
Imagine this controller.

``` php
class UserController {
    // Will not work for localhost/user/13
    // Because it looks for a action named 13 which doesn't exist.
    public function indexAction($id) {...}
}
```
## How did you fix it?

Instead of using the variable $parts and just using first value as a controller, second as method and so on.

The updated version instead send the first index from $parts to the dispatcher as a controller name, checks if valid.
If the controller is valid then it will remove the first index from $parts.
If it' not valid or there is no first value from $parts then the default controller will be used and still continue.

The next stage is to check action name and it uses the same first index as before.
Then the process is the same as for controller.

The the rest will be parameters for the action.
You can check the code for more information.
## Cool, does the fix work?

Yes! Works like a charm!
...but it's not perfect.

A problem occurs where the parameter list can cause some problems.

An example of problem:

``` php
class IndexController {
    // Will work for localhost
    public function indexAction() {...}

    // Will work for localhost/about.
    public function aboutAction() {...}
}
class UserController {
    // Will work for localhost/user
    public function indexAction() {...}
}
```

Where is the problem? Well if you are going to following route: `localhost/not/valid`
It will then go to IndexController::indexAction() with the params: `["not", "valid"]`.

This will result as there will be no 404 pages when you have defined IndexController::indexAction().
## How did you fix the params problem?

Even though PHP doesn't complain when sending to many parameters, I think it should not be done anyway.
I wanted to somehow validate the parameters list and throw 404 error when the parameter list is too large or small.
So I updated `CDispatcherBasic` and added a method so it can validate the parameter list like this:

``` php
public function isParamsValid()
{
    $reflection = new \ReflectionMethod($this->controller, $this->action);
    $numberOfParams = count($this->params);

    if ($numberOfParams >= $reflection->getNumberOfRequiredParameters()
        && $numberOfParams <= $reflection->getNumberOfParameters()) {
        return true;
    }

    return false;
}
```
## Conclusion

You may ask the question: "Will this pull request be compatible with the older versions?" and the answer is "I don't know".
I can't say for sure if this is compatible but I have tested it with my me-sida from phpmvc and it works fine.
Either you can release this as a new major release or a minor patch. It's up to you.

I don't know if you want this feature or not but I could recommend it and I don't know much about security but allowing users to send unexpected variables into the system could be one of them.
If you don't like this change, don't be afraid to tell me. I can do any changes if you want to and I can also send a pull request containing only the minor updates.

Sorry for the long text.

Regards,
Dennis Skoko
